### PR TITLE
Updated logic that determines if filter is enabled

### DIFF
--- a/FilterStateBehavior.php
+++ b/FilterStateBehavior.php
@@ -45,13 +45,15 @@ class FilterStateBehavior extends Behavior {
         // Filter
         /** @var \yii\grid\DataColumn $column */
         foreach ($gridView->columns as $column) {
-            if (!$column instanceof DataColumn
-                || $column->attribute === null
-                || $column->filter == false) {
-                continue;
-            }
 
-            $this->composeFilterState($column);
+            if($column instanceof DataColumn
+                && $column->filter !== false
+                && $column->grid->filterModel instanceof \yii\base\Model
+                && $column->attribute !== null
+                && $column->grid->filterModel->isAttributeActive($column->attribute)) {
+                $this->composeFilterState($column);
+            }
+            
         }
         // Sort
         if ($gridView->dataProvider->getSort() !== false) {


### PR DESCRIPTION
Updated grid-view-state behavior logic that determines if filter is enabled for column to match the logic inside Yii default yii\grid\DataColumn::renderFilterCellContent() method. Otherwise there could be situations when filter is available for DataColumn, but state is not saved.